### PR TITLE
fix: improve sensor availability stability and add retry logic

### DIFF
--- a/custom_components/ostrom_advanced/__init__.py
+++ b/custom_components/ostrom_advanced/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .api import OstromApiClient
+from .api import OstromApiClient, OstromAuthError
 from .const import (
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
@@ -99,6 +99,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             LOGGER.info("Successfully fetched initial price data")
             last_error = None
             break
+        except OstromAuthError:
+            # Permanent failure (bad credentials/config) — no point retrying
+            raise
         except Exception as err:
             last_error = err
             if attempt < len(_initial_retry_delays):

--- a/custom_components/ostrom_advanced/__init__.py
+++ b/custom_components/ostrom_advanced/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -88,15 +90,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             update_offset_seconds=update_offset_seconds,
         )
 
-    # Perform initial data fetch
-    # This will raise ConfigEntryNotReady if it fails
-    try:
-        await price_coordinator.async_config_entry_first_refresh()
-        LOGGER.info("Successfully fetched initial price data")
-    except Exception as err:
-        LOGGER.error("Failed to fetch initial price data: %s", err)
-        # Re-raise to trigger ConfigEntryNotReady
-        raise
+    # Perform initial data fetch with retries to handle temporary network issues at startup
+    _initial_retry_delays = [10, 30]  # seconds between attempts
+    last_error = None
+    for attempt in range(len(_initial_retry_delays) + 1):
+        try:
+            await price_coordinator.async_config_entry_first_refresh()
+            LOGGER.info("Successfully fetched initial price data")
+            last_error = None
+            break
+        except Exception as err:
+            last_error = err
+            if attempt < len(_initial_retry_delays):
+                delay = _initial_retry_delays[attempt]
+                LOGGER.warning(
+                    "Initial price fetch failed (attempt %d/%d), retrying in %ds: %s",
+                    attempt + 1,
+                    len(_initial_retry_delays) + 1,
+                    delay,
+                    err,
+                )
+                await asyncio.sleep(delay)
+    if last_error is not None:
+        LOGGER.error(
+            "Failed to fetch initial price data after %d attempts: %s",
+            len(_initial_retry_delays) + 1,
+            last_error,
+        )
+        raise last_error
 
     # Consumption data only if contract_id is provided
     if consumption_coordinator:

--- a/custom_components/ostrom_advanced/api.py
+++ b/custom_components/ostrom_advanced/api.py
@@ -25,6 +25,9 @@ from .const import (
     RESOLUTION_HOUR,
 )
 
+MAX_NETWORK_RETRIES = 2
+NETWORK_RETRY_DELAYS = [5, 15]  # seconds between retries
+
 
 class OstromApiError(HomeAssistantError):
     """Exception for Ostrom API errors."""
@@ -253,76 +256,98 @@ class OstromApiClient:
             {k: v for k, v in headers.items() if k != "Authorization"},
         )
 
-        try:
-            async with self._session.request(
-                method,
-                url,
-                headers=headers,
-                params=params,
-                json=json_data,
-                timeout=ClientTimeout(total=DEFAULT_TIMEOUT),
-            ) as response:
-                if response.status == 401:
-                    # Token might be expired, try to refresh
-                    LOGGER.warning("Token expired, attempting to refresh")
-                    self._access_token = None
-                    # Use lock to prevent race conditions during token refresh
-                    async with self._token_lock:
-                        # Check again after acquiring lock
-                        if not self._is_token_valid():
-                            await self.async_authenticate()
-                    # Retry the request once
-                    headers["Authorization"] = f"Bearer {self._access_token}"
-                    async with self._session.request(
-                        method,
-                        url,
-                        headers=headers,
-                        params=params,
-                        json=json_data,
-                        timeout=ClientTimeout(total=DEFAULT_TIMEOUT),
-                    ) as retry_response:
-                        if retry_response.status == 401:
-                            raise OstromAuthError("Authentication failed after refresh")
-                        retry_response.raise_for_status()
-                        return await retry_response.json()
+        for attempt in range(MAX_NETWORK_RETRIES + 1):
+            try:
+                async with self._session.request(
+                    method,
+                    url,
+                    headers=headers,
+                    params=params,
+                    json=json_data,
+                    timeout=ClientTimeout(total=DEFAULT_TIMEOUT),
+                ) as response:
+                    if response.status == 401:
+                        # Token might be expired, try to refresh
+                        LOGGER.warning("Token expired, attempting to refresh")
+                        self._access_token = None
+                        # Use lock to prevent race conditions during token refresh
+                        async with self._token_lock:
+                            # Check again after acquiring lock
+                            if not self._is_token_valid():
+                                await self.async_authenticate()
+                        # Retry the request once
+                        headers["Authorization"] = f"Bearer {self._access_token}"
+                        async with self._session.request(
+                            method,
+                            url,
+                            headers=headers,
+                            params=params,
+                            json=json_data,
+                            timeout=ClientTimeout(total=DEFAULT_TIMEOUT),
+                        ) as retry_response:
+                            if retry_response.status == 401:
+                                raise OstromAuthError("Authentication failed after refresh")
+                            retry_response.raise_for_status()
+                            return await retry_response.json()
 
-                if response.status == 400:
-                    error_text = await response.text()
-                    LOGGER.error("Bad request: %s", error_text)
-                    raise OstromApiError(f"Bad request: {error_text}")
+                    if response.status == 400:
+                        error_text = await response.text()
+                        LOGGER.error("Bad request: %s", error_text)
+                        raise OstromApiError(f"Bad request: {error_text}")
 
-                if response.status == 404:
-                    error_text = await response.text()
-                    LOGGER.error("Resource not found: %s", error_text)
-                    raise OstromApiError(
-                        f"Resource not found: {error_text}", status_code=404
+                    if response.status == 404:
+                        error_text = await response.text()
+                        LOGGER.error("Resource not found: %s", error_text)
+                        raise OstromApiError(
+                            f"Resource not found: {error_text}", status_code=404
+                        )
+
+                    if response.status == 429:
+                        LOGGER.error("Rate limit exceeded")
+                        raise OstromApiError("Rate limit exceeded")
+
+                    if response.status != 200:
+                        error_text = await response.text()
+                        LOGGER.error("API error: %s - %s", response.status, error_text)
+                        raise OstromApiError(
+                            f"API request failed with status {response.status}"
+                        )
+
+                    return await response.json()
+
+            except ClientConnectorError as err:
+                if attempt < MAX_NETWORK_RETRIES:
+                    delay = NETWORK_RETRY_DELAYS[attempt]
+                    LOGGER.warning(
+                        "Network error (attempt %d/%d), retrying in %ds: %s",
+                        attempt + 1,
+                        MAX_NETWORK_RETRIES + 1,
+                        delay,
+                        err,
                     )
-
-                if response.status == 429:
-                    LOGGER.error("Rate limit exceeded")
-                    raise OstromApiError("Rate limit exceeded")
-
-                if response.status != 200:
-                    error_text = await response.text()
-                    LOGGER.error("API error: %s - %s", response.status, error_text)
-                    raise OstromApiError(
-                        f"API request failed with status {response.status}"
+                    await asyncio.sleep(delay)
+                    continue
+                LOGGER.error("Network connection error: %s", err)
+                raise OstromApiError(f"Network error: {err}") from err
+            except asyncio.TimeoutError as err:
+                if attempt < MAX_NETWORK_RETRIES:
+                    delay = NETWORK_RETRY_DELAYS[attempt]
+                    LOGGER.warning(
+                        "Request timeout (attempt %d/%d), retrying in %ds",
+                        attempt + 1,
+                        MAX_NETWORK_RETRIES + 1,
+                        delay,
                     )
-
-                return await response.json()
-
-        except ClientConnectorError as err:
-            LOGGER.error("Network connection error: %s", err)
-            raise OstromApiError(f"Network error: {err}") from err
-        except asyncio.TimeoutError as err:
-            LOGGER.error("Request timeout: %s", err)
-            raise OstromApiError("Request timeout") from err
-        except ClientResponseError as err:
-            LOGGER.error("HTTP error: %s - %s", err.status, err.message)
-            raise OstromApiError(f"HTTP error {err.status}: {err.message}") from err
-        except aiohttp.ClientError as err:
-            LOGGER.error("Connection error: %s", err)
-            raise OstromApiError(f"Connection error: {err}") from err
+                    await asyncio.sleep(delay)
+                    continue
+                LOGGER.error("Request timeout: %s", err)
+                raise OstromApiError("Request timeout") from err
+            except ClientResponseError as err:
+                LOGGER.error("HTTP error: %s - %s", err.status, err.message)
+                raise OstromApiError(f"HTTP error {err.status}: {err.message}") from err
+            except aiohttp.ClientError as err:
+                LOGGER.error("Connection error: %s", err)
+                raise OstromApiError(f"Connection error: {err}") from err
 
     async def async_get_spot_prices(
         self, start: datetime, end: datetime

--- a/custom_components/ostrom_advanced/binary_sensor.py
+++ b/custom_components/ostrom_advanced/binary_sensor.py
@@ -253,6 +253,11 @@ class OstromCheapest3hBlockBinarySensor(
         )
 
     @property
+    def available(self) -> bool:
+        """Return True if we have data, even if the last update failed."""
+        return self.coordinator.data is not None
+
+    @property
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor."""
         if self.coordinator.data is None:

--- a/custom_components/ostrom_advanced/binary_sensor.py
+++ b/custom_components/ostrom_advanced/binary_sensor.py
@@ -254,8 +254,17 @@ class OstromCheapest3hBlockBinarySensor(
 
     @property
     def available(self) -> bool:
-        """Return True if we have data, even if the last update failed."""
-        return self.coordinator.data is not None
+        """Return True if coordinator has data from today.
+
+        Stays available during transient failures, but goes unavailable if
+        cached data has crossed a date boundary to avoid signaling stale blocks.
+        """
+        if self.coordinator.data is None:
+            return False
+        last_update = self.coordinator.data.get("last_update")
+        if last_update is None:
+            return True
+        return last_update.date() == dt_util.now().date()
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/ostrom_advanced/coordinator.py
+++ b/custom_components/ostrom_advanced/coordinator.py
@@ -21,6 +21,8 @@ from .const import (
 )
 from .utils import calculate_next_update_time
 
+RETRY_ON_ERROR_SECONDS = 120  # 2 Minuten bei Fehler erneut versuchen
+
 
 class OstromBaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Base coordinator with common scheduling logic."""
@@ -51,15 +53,46 @@ class OstromBaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._update_timer: asyncio.TimerHandle | None = None
 
     @callback
-    def _schedule_next_update(self, log_name: str = "update") -> None:
+    def _schedule_next_update(self, log_name: str = "update", retry_on_error: bool = False) -> None:
         """Schedule the next update based on interval and offset.
 
         Args:
             log_name: Name for logging (e.g., "price" or "consumption")
+            retry_on_error: If True, schedule a quick retry instead of full interval
         """
         # Cancel existing timer if any
         if self._update_timer:
             self._update_timer.cancel()
+
+        # Safe callback wrapper that ensures timer is always rescheduled on errors
+        def _safe_schedule_callback():
+            """Safe callback wrapper that ensures timer is always rescheduled."""
+            try:
+                self.hass.async_create_task(self.async_request_refresh())
+            except Exception as err:
+                LOGGER.error(
+                    "Failed to schedule %s update: %s, rescheduling with fallback",
+                    log_name,
+                    err,
+                )
+                # Reschedule with fallback delay (next interval) to keep loop running
+                fallback_delay = self._poll_interval_minutes * 60
+                self._update_timer = self.hass.loop.call_later(
+                    fallback_delay, _safe_schedule_callback
+                )
+
+        # Quick retry after error (2 minutes) instead of waiting full interval
+        if retry_on_error:
+            delay_seconds = RETRY_ON_ERROR_SECONDS
+            LOGGER.debug(
+                "Scheduling retry %s update in %.0f seconds due to error",
+                log_name,
+                delay_seconds,
+            )
+            self._update_timer = self.hass.loop.call_later(
+                delay_seconds, _safe_schedule_callback
+            )
+            return
 
         # Calculate next update time
         next_update = calculate_next_update_time(
@@ -80,23 +113,6 @@ class OstromBaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             next_update,
             delay_seconds,
         )
-
-        # Safe callback wrapper that ensures timer is always rescheduled on errors
-        def _safe_schedule_callback():
-            """Safe callback wrapper that ensures timer is always rescheduled."""
-            try:
-                self.hass.async_create_task(self.async_request_refresh())
-            except Exception as err:
-                LOGGER.error(
-                    "Failed to schedule %s update: %s, rescheduling with fallback",
-                    log_name,
-                    err,
-                )
-                # Reschedule with fallback delay (next interval) to keep loop running
-                fallback_delay = self._poll_interval_minutes * 60
-                self._update_timer = self.hass.loop.call_later(
-                    fallback_delay, _safe_schedule_callback
-                )
 
         # Schedule the update
         self._update_timer = self.hass.loop.call_later(
@@ -145,9 +161,9 @@ class OstromPriceCoordinator(OstromBaseCoordinator):
         self._client = client
 
     @callback
-    def _schedule_next_update(self) -> None:
+    def _schedule_next_update(self, retry_on_error: bool = False) -> None:
         """Schedule the next update based on interval and offset."""
-        super()._schedule_next_update("price")
+        super()._schedule_next_update("price", retry_on_error=retry_on_error)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch price data from the API.
@@ -255,18 +271,18 @@ class OstromPriceCoordinator(OstromBaseCoordinator):
             raise
         except OstromAuthError as err:
             LOGGER.error("Authentication error fetching prices: %s", err)
-            # Schedule next update even on error
-            self._schedule_next_update()
+            # Quick retry after error
+            self._schedule_next_update(retry_on_error=True)
             raise UpdateFailed(f"Authentication error: {err}") from err
         except OstromApiError as err:
             LOGGER.error("API error fetching prices: %s", err)
-            # Schedule next update even on error
-            self._schedule_next_update()
+            # Quick retry after error
+            self._schedule_next_update(retry_on_error=True)
             raise UpdateFailed(f"API error: {err}") from err
         except Exception as err:
             LOGGER.error("Unexpected error fetching prices: %s", err)
-            # Schedule next update even on error
-            self._schedule_next_update()
+            # Quick retry after error
+            self._schedule_next_update(retry_on_error=True)
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
 
@@ -302,9 +318,9 @@ class OstromConsumptionCoordinator(OstromBaseCoordinator):
         self._client = client
 
     @callback
-    def _schedule_next_update(self) -> None:
+    def _schedule_next_update(self, retry_on_error: bool = False) -> None:
         """Schedule the next update based on interval and offset."""
-        super()._schedule_next_update("consumption")
+        super()._schedule_next_update("consumption", retry_on_error=retry_on_error)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch consumption data from the API.
@@ -399,16 +415,16 @@ class OstromConsumptionCoordinator(OstromBaseCoordinator):
             raise
         except OstromAuthError as err:
             LOGGER.error("Authentication error fetching consumption: %s", err)
-            # Schedule next update even on error
-            self._schedule_next_update()
+            # Quick retry after error
+            self._schedule_next_update(retry_on_error=True)
             raise UpdateFailed(f"Authentication error: {err}") from err
         except OstromApiError as err:
             LOGGER.error("API error fetching consumption: %s", err)
-            # Schedule next update even on error
-            self._schedule_next_update()
+            # Quick retry after error
+            self._schedule_next_update(retry_on_error=True)
             raise UpdateFailed(f"API error: {err}") from err
         except Exception as err:
             LOGGER.error("Unexpected error fetching consumption: %s", err)
-            # Schedule next update even on error
-            self._schedule_next_update()
+            # Quick retry after error
+            self._schedule_next_update(retry_on_error=True)
             raise UpdateFailed(f"Unexpected error: {err}") from err

--- a/custom_components/ostrom_advanced/sensor.py
+++ b/custom_components/ostrom_advanced/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTRIBUTION,
@@ -756,8 +757,17 @@ class OstromPriceSensor(CoordinatorEntity[OstromPriceCoordinator], SensorEntity)
 
     @property
     def available(self) -> bool:
-        """Return True if we have data, even if the last update failed."""
-        return self.coordinator.data is not None
+        """Return True if coordinator has data from today.
+
+        Stays available during transient failures, but goes unavailable if
+        cached data has crossed a date boundary to avoid showing stale slots.
+        """
+        if self.coordinator.data is None:
+            return False
+        last_update = self.coordinator.data.get("last_update")
+        if last_update is None:
+            return True
+        return last_update.date() == dt_util.now().date()
 
     @property
     def native_value(self) -> Any:
@@ -820,8 +830,17 @@ class OstromConsumptionSensor(
 
     @property
     def available(self) -> bool:
-        """Return True if we have data, even if the last update failed."""
-        return self.coordinator.data is not None
+        """Return True if coordinator has data from today.
+
+        Stays available during transient failures, but goes unavailable if
+        cached data has crossed a date boundary to avoid showing stale slots.
+        """
+        if self.coordinator.data is None:
+            return False
+        last_update = self.coordinator.data.get("last_update")
+        if last_update is None:
+            return True
+        return last_update.date() == dt_util.now().date()
 
     @property
     def native_value(self) -> Any:

--- a/custom_components/ostrom_advanced/sensor.py
+++ b/custom_components/ostrom_advanced/sensor.py
@@ -755,6 +755,11 @@ class OstromPriceSensor(CoordinatorEntity[OstromPriceCoordinator], SensorEntity)
         )
 
     @property
+    def available(self) -> bool:
+        """Return True if we have data, even if the last update failed."""
+        return self.coordinator.data is not None
+
+    @property
     def native_value(self) -> Any:
         """Return the state of the sensor."""
         if self.coordinator.data is None:
@@ -814,6 +819,11 @@ class OstromConsumptionSensor(
         )
 
     @property
+    def available(self) -> bool:
+        """Return True if we have data, even if the last update failed."""
+        return self.coordinator.data is not None
+
+    @property
     def native_value(self) -> Any:
         """Return the state of the sensor."""
         if self.coordinator.data is None:
@@ -867,8 +877,8 @@ class OstromCostSensor(SensorEntity):
     def available(self) -> bool:
         """Return if entity is available."""
         return (
-            self._price_coordinator.last_update_success
-            and self._consumption_coordinator.last_update_success
+            self._price_coordinator.data is not None
+            and self._consumption_coordinator.data is not None
         )
 
     @property


### PR DESCRIPTION
- Override `available` in OstromPriceSensor, OstromConsumptionSensor and
  OstromCostSensor to return True when data is present, regardless of
  last_update_success. Sensors now show the last known value instead of
  going unavailable on transient API failures.

- Add quick retry scheduling (2 min) on coordinator errors instead of
  waiting the full 15-min interval before trying again.

- Add network-level retry logic in api.py: up to 2 retries with 5s/15s
  delays for ClientConnectorError and TimeoutError before propagating
  the error to the coordinator.

- Add retry logic for the initial price fetch in __init__.py: up to 3
  attempts (with 10s and 30s delays) so that a brief network delay at
  HA startup does not leave all entities offline.

https://claude.ai/code/session_01WiPP9qhyWcpdjLnXWcFYij